### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/Turducken/AppDelegate.swift
+++ b/Turducken/AppDelegate.swift
@@ -11,7 +11,7 @@ import CoreLocation
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        FanMakerSDK.initialize(apiKey: "bb460452f81404b2cdf8d5691714115bb1b25905d337cc4ea50c89f327d7209d")
+        FanMakerSDK.initialize(apiKey: "")
         
         return true
     }


### PR DESCRIPTION
We should remove the valid apikey from the repo because it is public. Also partners should use their keys not the pipboy key.

I'm also going to remove this pipboy key from the api token table too since it has been exposed to the World